### PR TITLE
SSH directly to host OS to avoid balena CLI incompatible version error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # shellcheck disable=SC2002
-cat batch | stdbuf -oL xargs -I{} -P 30 /bin/sh -c "cat task.sh | balena ssh {} | sed 's/^/{} : /' | tee -a task.log"
+cat batch | stdbuf -oL xargs -I{} -P 30 /bin/sh -c "cat task.sh | ssh -p 22222 root@{} | sed 's/^/{} : /' | tee -a task.log"


### PR DESCRIPTION
Error example:

```
c141316 : error: The device 'c14131603b5540c988d8edb4a4cee62a' does not support direct host OS access, please update the device to at least version balenaOS '2.7.5' 
```

"Batch" file should now be a list of IP addrs, instead of Balena ids

Helper script for grabbing IP addresses

```
 nmap -p 22222 --open -sV 10.0.0.0/24  | grep "scan report for" | grep -o "10.*"
```